### PR TITLE
fix focused email input width on mobile

### DIFF
--- a/src/components/NewsletterSignup.js
+++ b/src/components/NewsletterSignup.js
@@ -39,6 +39,7 @@ const NewsletterForm = styled.div`
 		border: none;
 		color: inherit;
 		outline: none !important;
+		width: 100%;
 	}
 
 	input[value='']:not(:focus) {


### PR DESCRIPTION
Originally, on small screens the email input took up too much space when focused, pushing the subscribe button off to one side:

<img src="https://user-images.githubusercontent.com/19466326/58223668-938ebf80-7d12-11e9-800c-eb5d475a7023.png" width="400" />

Fixed:

<img src="https://user-images.githubusercontent.com/19466326/58223685-a3a69f00-7d12-11e9-83ff-bb418f4e2509.png" width="400" />
