### PR TITLE
halve vertex count

### DIFF
--- a/src/components/Waves.js
+++ b/src/components/Waves.js
@@ -40,7 +40,7 @@ function getColor(index) {
 	)
 }
 
-const count = 2000
+const count = 1000
 function createWave({ canvas, count, ctx, fill }, speed) {
 	const values = {
 		a: Math.random() * 2,
@@ -73,9 +73,9 @@ function createWave({ canvas, count, ctx, fill }, speed) {
 		render() {
 			const height = canvas.height
 			const width = canvas.clientWidth
-			const step = width > 2000
-				? count / 10000
-				: count / (width * 5)
+			const step = width > 1600
+				? count / 3200
+				: count / (width * 2)
 			const nextY = getNextY()
 
 			points.pop()


### PR DESCRIPTION
This roughly cuts the processing time per animation frame in half, at the cost of stretching the image further on larger screens (starts stretching at 1600px rather than 2000 as previously), and makes the stretching more obvious. Feels like a reasonable trade-off considering the typical resolutions of screens according to analytics!